### PR TITLE
DeletePropTypes (style changed to ViewStyleProp)

### DIFF
--- a/Libraries/Experimental/SwipeableRow/SwipeableQuickActions.js
+++ b/Libraries/Experimental/SwipeableRow/SwipeableQuickActions.js
@@ -10,7 +10,6 @@
 
 'use strict';
 
-const DeprecatedViewPropTypes = require('DeprecatedViewPropTypes');
 const React = require('React');
 const StyleSheet = require('StyleSheet');
 const View = require('View');
@@ -25,11 +24,13 @@ const View = require('View');
  *   <SwipeableQuickActionButton {..props} />
  * </SwipeableQuickActions>
  */
-class SwipeableQuickActions extends React.Component<{style?: $FlowFixMe}> {
-  static propTypes = {
-    style: DeprecatedViewPropTypes.style,
-  };
+import type {ViewStyleProp} from 'StyleSheet';
 
+type Props = $ReadOnly<{|
+  style?: ?ViewStyleProp,
+|}>;
+
+class SwipeableQuickActions extends React.Component<Props> {
   render(): React.Node {
     // $FlowFixMe found when converting React.createClass to ES6
     const children = this.props.children;

--- a/Libraries/Experimental/SwipeableRow/SwipeableQuickActions.js
+++ b/Libraries/Experimental/SwipeableRow/SwipeableQuickActions.js
@@ -27,7 +27,7 @@ const View = require('View');
 import type {ViewStyleProp} from 'StyleSheet';
 
 type Props = $ReadOnly<{|
-  style?: ?ViewStyleProp,
+  style?: ViewStyleProp,
 |}>;
 
 class SwipeableQuickActions extends React.Component<Props> {


### PR DESCRIPTION
Related to #21342
This PR removes DeprecatedViewPropTypes to ViewStyleProp


Test Plan:
----------
Flow tests succeed

- [x] yarn prettier
- [x] yarn flow-check-android
- [x] yarn flow-check-ios


Release Notes:
--------------

[GENERAL] [ENHANCEMENT] [SwipeableQuickActions.js] replace prop-types by Flow

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
